### PR TITLE
Support passing custom cwd path + add more tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 
 Get git strings like a git describe reference or git commit hash.
 
+**Requirements:**
+
+- [git](https://git-scm.com/) must be installed on your system and resolvable in your shell `PATH`.
 
 ## Installation
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,19 @@
 import { execSync } from 'child_process';
 
 /**
- * Get the HEAD git reference via `git describe`.
+ * Get the HEAD git reference via [git describe](https://git-scm.com/docs/git-describe).
  *
- * @see <https://git-scm.com/docs/git-describe>
- *
- * @param args - Additional arguments to pass to `git describe`. The default
- * is `'--dirty="-dev" --broken'`.
  * @param cwd - Modify the working directory git is executed in (default is the
  * directory of the current node process).
  * @returns A human readable git reference.
  */
-export function gitRef(args = '--dirty="-dev" --broken', cwd?: string): string {
+export function gitRef(cwd?: string): string {
   let reference = '';
 
   try {
-    const result = execSync(`git describe --always ${args}`, { cwd });
+    const result = execSync('git describe --always --dirty="-dev" --broken', {
+      cwd,
+    });
     reference = result.toString().trim();
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,13 +7,15 @@ import { execSync } from 'child_process';
  *
  * @param args - Additional arguments to pass to `git describe`. The default
  * is `'--dirty="-dev" --broken'`.
+ * @param cwd - Modify the working directory git is executed in (default is the
+ * directory of the current node process).
  * @returns A human readable git reference.
  */
-export function gitRef(args = '--dirty="-dev" --broken'): string {
+export function gitRef(args = '--dirty="-dev" --broken', cwd?: string): string {
   let reference = '';
 
   try {
-    const result = execSync(`git describe --always ${args}`) || '';
+    const result = execSync(`git describe --always ${args}`, { cwd });
     reference = result.toString().trim();
   } catch (error) {
     // eslint-disable-next-line no-console
@@ -30,13 +32,17 @@ export default gitRef;
  *
  * @param long - Get the full git hash instead of a short hash in the form of
  * the first 7 characters (default `false`).
+ * @param cwd - Modify the working directory git is executed in (default is the
+ * directory of the current node process).
  * @returns The git commit hash.
  */
-export function gitHash(long?: boolean): string {
+export function gitHash(long?: boolean, cwd?: string): string {
   let hash = '';
 
   try {
-    const result = execSync(`git rev-parse${long ? '' : ' --short'} HEAD`) || '';
+    const result = execSync(`git rev-parse${long ? '' : ' --short'} HEAD`, {
+      cwd,
+    });
     hash = result.toString().trim();
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -45,14 +45,14 @@ describe('gitRef', (test) => {
 
   test('returns empty string in non-git dir', () => {
     const dir = getTempDir('not-git');
-    const result = gitRef(undefined, dir);
+    const result = gitRef(dir);
     assert.is(result, '');
   });
 
   test('returns empty string in repo without commits', () => {
     const dir = getTempDir('no-commit');
     execCmds(dir, ['git init --quiet']);
-    const result = gitRef(undefined, dir);
+    const result = gitRef(dir);
     assert.is(result, '');
   });
 
@@ -66,7 +66,7 @@ describe('gitRef', (test) => {
       'git add file.txt',
       'git commit --quiet --no-gpg-sign -m "commit1"',
     ]);
-    const result = gitRef(undefined, dir);
+    const result = gitRef(dir);
     assert.type(result, 'string');
     assert.is(result.length, 7);
   });
@@ -82,7 +82,7 @@ describe('gitRef', (test) => {
       'git commit --quiet --no-gpg-sign -m "commit1"',
       'git tag --no-sign -m "v123" v123',
     ]);
-    const result = gitRef(undefined, dir);
+    const result = gitRef(dir);
     assert.is(result, 'v123');
   });
 
@@ -96,7 +96,7 @@ describe('gitRef', (test) => {
       'git add file1.txt',
       'git commit --quiet --no-gpg-sign -m "commit1"',
     ]);
-    const result1 = gitRef(undefined, dir);
+    const result1 = gitRef(dir);
     assert.type(result1, 'string');
     assert.is(result1.length, 7);
     execCmds(dir, [
@@ -104,12 +104,12 @@ describe('gitRef', (test) => {
       'git add file2.txt',
       'git commit --quiet --no-gpg-sign -m "commit2"',
     ]);
-    const result2 = gitRef(undefined, dir);
+    const result2 = gitRef(dir);
     assert.type(result2, 'string');
     assert.is(result2.length, 7);
     assert.is.not(result1, result2);
     execCmds(dir, ['git tag --no-sign -m "v1" v1']);
-    const result3 = gitRef(undefined, dir);
+    const result3 = gitRef(dir);
     assert.is(result3, 'v1');
     assert.is.not(result2, result3);
     execCmds(dir, [
@@ -118,7 +118,7 @@ describe('gitRef', (test) => {
       'git commit --quiet --no-gpg-sign -m "commit3"',
       'git tag --no-sign -m "v2" v2',
     ]);
-    const result4 = gitRef(undefined, dir);
+    const result4 = gitRef(dir);
     assert.is(result4, 'v2');
     assert.is.not(result3, result4);
     execCmds(dir, [
@@ -126,7 +126,7 @@ describe('gitRef', (test) => {
       'git add file4.txt',
       'git commit --quiet --no-gpg-sign -m "commit4"',
     ]);
-    const result5 = gitRef(undefined, dir);
+    const result5 = gitRef(dir);
     assert.is(result5.length, 13);
     assert.ok(result5.startsWith('v2-1-'));
     assert.is.not(result4, result5);
@@ -144,7 +144,7 @@ describe('gitRef', (test) => {
       'touch file2.txt',
       'git add file2.txt',
     ]);
-    const result = gitRef(undefined, dir);
+    const result = gitRef(dir);
     assert.type(result, 'string');
     assert.ok(result.endsWith('-dev'));
   });
@@ -160,7 +160,7 @@ describe('gitRef', (test) => {
       'git commit --quiet --no-gpg-sign -m "commit1"',
       "sed -i 's/file.txt/corrupted.txt/g' ./.git/index",
     ]);
-    const result = gitRef(undefined, dir);
+    const result = gitRef(dir);
     assert.type(result, 'string');
     assert.ok(result.endsWith('-broken'));
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -60,6 +60,8 @@ describe('gitRef', (test) => {
     const dir = getTempDir('with-commit');
     execCmds(dir, [
       'git init --quiet',
+      'git config user.email "test@test.com"',
+      'git config user.name "Test Test"',
       'touch file.txt',
       'git add file.txt',
       'git commit --quiet --no-gpg-sign -m "commit1"',
@@ -73,6 +75,8 @@ describe('gitRef', (test) => {
     const dir = getTempDir('with-tag');
     execCmds(dir, [
       'git init --quiet',
+      'git config user.email "test@test.com"',
+      'git config user.name "Test Test"',
       'touch file.txt',
       'git add file.txt',
       'git commit --quiet --no-gpg-sign -m "commit1"',
@@ -86,6 +90,8 @@ describe('gitRef', (test) => {
     const dir = getTempDir('dirty-tree');
     execCmds(dir, [
       'git init --quiet',
+      'git config user.email "test@test.com"',
+      'git config user.name "Test Test"',
       'touch file.txt',
       'git add file.txt',
       'git commit --quiet --no-gpg-sign -m "commit1"',
@@ -101,6 +107,8 @@ describe('gitRef', (test) => {
     const dir = getTempDir('broken-tree');
     execCmds(dir, [
       'git init --quiet',
+      'git config user.email "test@test.com"',
+      'git config user.name "Test Test"',
       'touch file.txt',
       'git add file.txt',
       'git commit --quiet --no-gpg-sign -m "commit1"',

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -86,6 +86,52 @@ describe('gitRef', (test) => {
     assert.is(result, 'v123');
   });
 
+  test('returns the latest ref as the git tree changes', () => {
+    const dir = getTempDir('multiple-changes');
+    execCmds(dir, [
+      'git init --quiet',
+      'git config user.email "test@test.com"',
+      'git config user.name "Test Test"',
+      'touch file1.txt',
+      'git add file1.txt',
+      'git commit --quiet --no-gpg-sign -m "commit1"',
+    ]);
+    const result1 = gitRef(undefined, dir);
+    assert.type(result1, 'string');
+    assert.is(result1.length, 7);
+    execCmds(dir, [
+      'touch file2.txt',
+      'git add file2.txt',
+      'git commit --quiet --no-gpg-sign -m "commit2"',
+    ]);
+    const result2 = gitRef(undefined, dir);
+    assert.type(result2, 'string');
+    assert.is(result2.length, 7);
+    assert.is.not(result1, result2);
+    execCmds(dir, ['git tag --no-sign -m "v1" v1']);
+    const result3 = gitRef(undefined, dir);
+    assert.is(result3, 'v1');
+    assert.is.not(result2, result3);
+    execCmds(dir, [
+      'touch file3.txt',
+      'git add file3.txt',
+      'git commit --quiet --no-gpg-sign -m "commit3"',
+      'git tag --no-sign -m "v2" v2',
+    ]);
+    const result4 = gitRef(undefined, dir);
+    assert.is(result4, 'v2');
+    assert.is.not(result3, result4);
+    execCmds(dir, [
+      'touch file4.txt',
+      'git add file4.txt',
+      'git commit --quiet --no-gpg-sign -m "commit4"',
+    ]);
+    const result5 = gitRef(undefined, dir);
+    assert.is(result5.length, 13);
+    assert.ok(result5.startsWith('v2-1-'));
+    assert.is.not(result4, result5);
+  });
+
   test('appends "-dev" in repo with dirty tree (uncommitted changes)', () => {
     const dir = getTempDir('dirty-tree');
     execCmds(dir, [
@@ -158,5 +204,37 @@ describe('gitHash', (test) => {
     execCmds(dir, ['git init --quiet']);
     const result = gitHash(undefined, dir);
     assert.is(result, '');
+  });
+
+  test('returns the latest hash as the git tree changes', () => {
+    const dir = getTempDir('multiple-changes');
+    execCmds(dir, [
+      'git init --quiet',
+      'git config user.email "test@test.com"',
+      'git config user.name "Test Test"',
+      'touch file1.txt',
+      'git add file1.txt',
+      'git commit --quiet --no-gpg-sign -m "commit1"',
+    ]);
+    const result1 = gitHash(undefined, dir);
+    assert.type(result1, 'string');
+    assert.is(result1.length, 7);
+    execCmds(dir, [
+      'touch file2.txt',
+      'git add file2.txt',
+      'git commit --quiet --no-gpg-sign -m "commit2"',
+    ]);
+    const result2 = gitHash(undefined, dir);
+    assert.type(result2, 'string');
+    assert.is(result2.length, 7);
+    assert.is.not(result1, result2);
+    execCmds(dir, [
+      'touch file3.txt',
+      'git add file3.txt',
+      'git commit --quiet --no-gpg-sign -m "commit3"',
+    ]);
+    const result3 = gitHash(undefined, dir);
+    assert.is(result3.length, 7);
+    assert.is.not(result2, result3);
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,13 @@
 import * as assert from 'uvu/assert';
 import * as allExports from '../src/index';
 import { gitHash, gitRef } from '../src/index';
-import { describe } from './utils';
+import {
+  createTempDir,
+  deleteTempDir,
+  describe,
+  execCmds,
+  getTempDir,
+} from './utils';
 
 describe('exports', (test) => {
   (
@@ -22,32 +28,102 @@ describe('exports', (test) => {
   });
 });
 
-// TODO: Run in various other sample git repos, e.g.:
-// - without any commits
-// - with commits but without any tags
-// - with multiple tags
-// - with a dirty tree (uncommitted changes)
-// - in a broken repo
-// - not in a git repo
-// - in a git repo with commits but no HEAD ref
-
 describe('gitRef', (test) => {
+  test.before(createTempDir);
+  test.after(deleteTempDir);
+
   test('returns a non-empty string', () => {
     const result = gitRef();
-    assert.is.not(result, '');
     assert.type(result, 'string');
+    assert.is.not(result, '');
   });
 
   test('returns a tag git reference', () => {
     const result = gitRef();
     assert.is(/^v\d+\.\d+\.\d+/.test(result), true, 'matches expected format');
   });
+
+  test('returns empty string in non-git dir', () => {
+    const dir = getTempDir('not-git');
+    const result = gitRef(undefined, dir);
+    assert.is(result, '');
+  });
+
+  test('returns empty string in repo without commits', () => {
+    const dir = getTempDir('no-commit');
+    execCmds(dir, ['git init --quiet']);
+    const result = gitRef(undefined, dir);
+    assert.is(result, '');
+  });
+
+  test('returns short hash string in repo with commit but no tag', () => {
+    const dir = getTempDir('with-commit');
+    execCmds(dir, [
+      'git init --quiet',
+      'touch file.txt',
+      'git add file.txt',
+      'git commit --quiet --no-gpg-sign -m "commit1"',
+    ]);
+    const result = gitRef(undefined, dir);
+    assert.type(result, 'string');
+    assert.is(result.length, 7);
+  });
+
+  test('returns tag string in repo with tag', () => {
+    const dir = getTempDir('with-tag');
+    execCmds(dir, [
+      'git init --quiet',
+      'touch file.txt',
+      'git add file.txt',
+      'git commit --quiet --no-gpg-sign -m "commit1"',
+      'git tag --no-sign -m "v123" v123',
+    ]);
+    const result = gitRef(undefined, dir);
+    assert.is(result, 'v123');
+  });
+
+  test('appends "-dev" in repo with dirty tree (uncommitted changes)', () => {
+    const dir = getTempDir('dirty-tree');
+    execCmds(dir, [
+      'git init --quiet',
+      'touch file.txt',
+      'git add file.txt',
+      'git commit --quiet --no-gpg-sign -m "commit1"',
+      'touch file2.txt',
+      'git add file2.txt',
+    ]);
+    const result = gitRef(undefined, dir);
+    assert.type(result, 'string');
+    assert.ok(result.endsWith('-dev'));
+  });
+
+  test('appends "-broken" in repo with broken tree', () => {
+    const dir = getTempDir('broken-tree');
+    execCmds(dir, [
+      'git init --quiet',
+      'touch file.txt',
+      'git add file.txt',
+      'git commit --quiet --no-gpg-sign -m "commit1"',
+      "sed -i 's/file.txt/corrupted.txt/g' ./.git/index",
+    ]);
+    const result = gitRef(undefined, dir);
+    assert.type(result, 'string');
+    assert.ok(result.endsWith('-broken'));
+  });
 });
 
 describe('gitHash', (test) => {
-  test('returns a short git hash by default', () => {
+  test.before(createTempDir);
+  test.after(deleteTempDir);
+
+  test('returns a non-empty string', () => {
     const result = gitHash();
     assert.type(result, 'string');
+    assert.is.not(result, '');
+  });
+
+  test('returns a short git hash by default', () => {
+    const result = gitHash();
     assert.is(result.length, 7);
   });
 
@@ -61,5 +137,18 @@ describe('gitHash', (test) => {
     const result = gitHash(false);
     assert.type(result, 'string');
     assert.is(result.length, 7);
+  });
+
+  test('returns empty string in non-git dir', () => {
+    const dir = getTempDir('not-git');
+    const result = gitHash(undefined, dir);
+    assert.is(result, '');
+  });
+
+  test('returns empty string in repo without commits', () => {
+    const dir = getTempDir('no-commit');
+    execCmds(dir, ['git init --quiet']);
+    const result = gitHash(undefined, dir);
+    assert.is(result, '');
   });
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,5 +1,7 @@
-/* eslint-disable import/prefer-default-export */
-
+import { execSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { suite } from 'uvu';
 
 export function describe(
@@ -10,3 +12,51 @@ export function describe(
   fn(testSuite);
   testSuite.run();
 }
+
+let tmpDir: string | undefined;
+
+export async function createTempDir(): Promise<void> {
+  tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'git-ref-test-'));
+}
+
+export async function deleteTempDir(): Promise<void> {
+  if (!tmpDir) {
+    throw new Error(
+      'No temp directory exists, you need to call createTempDir() first',
+    );
+  }
+
+  await fs.promises.rm(tmpDir, {
+    force: true,
+    recursive: true,
+  });
+
+  tmpDir = undefined;
+}
+
+export function getTempDir(subDir?: string): string {
+  if (!tmpDir) {
+    throw new Error(
+      'No temp directory exists, you need to call createTempDir() first',
+    );
+  }
+
+  if (subDir) {
+    const newDir = path.join(tmpDir, subDir);
+    fs.mkdirSync(newDir);
+    return newDir;
+  }
+
+  return tmpDir;
+}
+
+export function execCmds(dir: string, cmds: string[]): void {
+  cmds.forEach((cmd) => {
+    execSync(cmd, {
+      cwd: dir,
+      timeout: 2000,
+    });
+  });
+}
+
+// export function runInDir(dir:string, cb)


### PR DESCRIPTION
- Support passing custom `cwd` path to change where git is executed
- Remove the ability to customise the git describe args to prevent arbitrary command injection
- Add tests to check results in various git tree conditions